### PR TITLE
[SALEOR-6636] Split events to syncEvents and asyncEvents.

### DIFF
--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -19,7 +19,7 @@ const handler: NextApiHandler = async (request, response) => {
     webhooks: [
       {
         name: "order-created",
-        events: ["ORDER_CREATED"],
+        asyncEvents: ["ORDER_CREATED"],
         query: print(OrderCreatedSubscriptionDocument),
         targetUrl: `${baseURL}/api/webhooks/order-created`,
         isActive: true,


### PR DESCRIPTION
Since Saleor 3.1 events in webhooks were splitted into syncEvents and asyncEvents and since then one list called events is depracted.