### PR TITLE
Fix 404 in dashboard extensions

### DIFF
--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -22,7 +22,7 @@ const handler: Handler = async (request) => {
     version: version,
     name: name,
     permissions: ["MANAGE_ORDERS"],
-    appUrl: `${baseURL}/configuration`,
+    appUrl: baseURL,
     tokenTargetUrl: `${baseURL}/api/register`,
     webhooks,
     extensions: [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,14 +7,14 @@ import useApp from "../hooks/useApp";
 
 const Index: NextPage = () => {
   const [isBrowser, setIsBrowser] = useState(false);
-  const router = useRouter()
+  const router = useRouter();
   const appState = useApp()?.getState();
 
   useEffect(() => {
     if (appState?.domain && isBrowser) {
-      router.push("/configuration", { query: location.search })
+      router.replace("/configuration", { query: location.search });
     }
-  }, [isBrowser])
+  }, [isBrowser]);
 
   useEffect(() => {
     setIsBrowser(true);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,20 @@
-import type { NextPage } from "next";
+import type { NextPage, } from "next";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import useApp from "../hooks/useApp";
+
 
 const Index: NextPage = () => {
   const [isBrowser, setIsBrowser] = useState(false);
+  const router = useRouter()
+  const appState = useApp()?.getState();
+
+  useEffect(() => {
+    if (appState?.domain && isBrowser) {
+      router.push("/configuration", { query: location.search })
+    }
+  }, [isBrowser])
 
   useEffect(() => {
     setIsBrowser(true);
@@ -11,6 +22,10 @@ const Index: NextPage = () => {
 
   const hostname = isBrowser ? window.location.hostname : undefined;
   const isTunnel = hostname?.includes("saleor.live");
+
+  if (!isBrowser || appState?.domain) {
+    return <p>Loading...</p>
+  }
 
   return (
     <div>


### PR DESCRIPTION
I want to merge this, because this PR fixes an issue when user visited orders dashboard extension the app returned 404 because the `appUrl` had `/configuration` suffix.
Saleor Core and Dashboard expect all extensions URLs to be a subpath of `appUrl`.
