### PR TITLE
Return error response if saving registration data has failed

### DIFF
--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -29,7 +29,7 @@ export const setEnvVars = async (variables: IEnvVar[]) => {
   console.debug("Setting environment variables: ", variables);
 
   if (process.env.VERCEL === "1") {
-    await fetch(process.env.SALEOR_REGISTER_APP_URL as string, {
+    const response = await fetch(process.env.SALEOR_REGISTER_APP_URL as string, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -37,6 +37,11 @@ export const setEnvVars = async (variables: IEnvVar[]) => {
         envs: variables.map(({ key, value }) => ({ key, value })),
       }),
     });
+    if (response.status !== 200) {
+      const errorMessage = `Setting up the environment variables failed. The API responded with status ${response.status}.`;
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
   } else {
     let currentEnvVars;
     try {

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -12,17 +12,23 @@ const handler: Handler = async (request) => {
   const authToken = request.params.auth_token;
   const saleorDomain = request.headers[SALEOR_DOMAIN_HEADER];
 
-  await setEnvVars([
-    {
-      key: "SALEOR_AUTH_TOKEN",
-      value: authToken,
-    },
-    {
-      key: "SALEOR_DOMAIN",
-      value: saleorDomain,
-    },
-  ]);
-
+  try {
+    await setEnvVars([
+      {
+        key: "SALEOR_AUTH_TOKEN",
+        value: authToken,
+      },
+      {
+        key: "SALEOR_DOMAIN",
+        value: saleorDomain,
+      },
+    ]);
+  } catch {
+    return Response.InternalServerError({
+      success: false,
+      message: "Registration failed: could not save the data.",
+    });
+  }
   return Response.OK({ success: true });
 };
 


### PR DESCRIPTION
If setting up variables for the deployed app has failed, `/api/register` should return error response 

Related to https://github.com/saleor/saleor-cli/issues/247