### PR TITLE
Fix import warning

### DIFF
--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -6,7 +6,7 @@ import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
 
 import * as GeneratedGraphQL from "../../generated/graphql";
-import packageInfo from "../../package.json";
+import packageJson from "../../package.json";
 
 const handler: Handler = async (request) => {
   const { baseURL } = request.context;
@@ -15,8 +15,8 @@ const handler: Handler = async (request) => {
 
   const manifest = {
     id: "saleor.app",
-    version: packageInfo.version,
-    name: packageInfo.name,
+    version: packageJson.version,
+    name: packageJson.name,
     permissions: ["MANAGE_ORDERS"],
     appUrl: baseURL,
     tokenTargetUrl: `${baseURL}/api/register`,

--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -6,7 +6,7 @@ import { toNextHandler } from "retes/adapter";
 import { Response } from "retes/response";
 
 import * as GeneratedGraphQL from "../../generated/graphql";
-import { name, version } from "../../package.json";
+import packageInfo from "../../package.json";
 
 const handler: Handler = async (request) => {
   const { baseURL } = request.context;
@@ -15,8 +15,8 @@ const handler: Handler = async (request) => {
 
   const manifest = {
     id: "saleor.app",
-    version,
-    name,
+    version: packageInfo.version,
+    name: packageInfo.name,
     permissions: ["MANAGE_ORDERS"],
     appUrl: baseURL,
     tokenTargetUrl: `${baseURL}/api/register`,


### PR DESCRIPTION
The manifest endpoint was producing warnings:
```
Should not import the named export 'version'  from default-exporting module (only default export is available soon)

./pages/api/manifest.ts
Should not import the named export 'name'  from default-exporting module (only default export is available soon)
````

This PR changes the import to address that.