### PR TITLE
Update register to return response in the format expected by dashboard

### DIFF
--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -17,7 +17,9 @@ const handler: Handler = async (request) => {
   } catch {
     return Response.InternalServerError({
       success: false,
-      message: "Registration failed: could not save the data.",
+      error: {
+        message: "Registration failed: could not save the auth data.",
+      },
     });
   }
   return Response.OK({ success: true });


### PR DESCRIPTION
Putting message at `error.message` allows displaying a custom message in the dashboard.