### PR TITLE
Add error screen for applications during deployment

### DIFF
--- a/pages/configuration.tsx
+++ b/pages/configuration.tsx
@@ -76,16 +76,34 @@ function Configuration() {
     );
   };
 
-  useEffect(() => {
-    if (error) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      notify({
-        status: "error",
-        title: "Something went wrong!",
-        text: "Couldn't fetch configuration data",
-      });
-    }
-  }, [error]);
+  if (error) {
+    console.error("Can't establish connection with the App API: ", error);
+    return (
+      <div>
+        <h1>⚠️ Can&apos;t connect with the App API</h1>
+        You may see this error because:
+        <ul>
+          <li>Internet connection has been lost</li>
+          <li>
+            Application installation process is still in progress. If you use Vercel, you may need
+            to wait for redeployment of the app - try again in a minute.
+          </li>
+          <li>
+            Application is misconfigured. If you would like to know more how auth configuration is
+            kept,{" "}
+            <a
+              href="https://github.com/saleor/saleor-app-sdk/blob/main/docs/apl.md"
+              target="_blank"
+              rel="noreferrer"
+            >
+              go to APL documentation
+            </a>
+            .
+          </li>
+        </ul>
+      </div>
+    );
+  }
 
   if (configuration === undefined) {
     return <Skeleton />;


### PR DESCRIPTION
Fixes #87 

Display a clear message if the configuration view can't fetch data from the API due to ongoing deployment.

Steps to reproduce:
- create a new app
- use code from this PR
- deploy the application with `saleor app deploy`
- install application
- imminently after installation navigate to app view in the dashboard
- for a sec "skeleton" views should be displayed: 
<img width="1077" alt="Zrzut ekranu 2022-09-30 o 13 35 08" src="https://user-images.githubusercontent.com/5188636/193275903-4e7efc0f-15e2-4c87-a255-b558e2bfd00f.png">

- application will fail to reach API (due to ongoing redeployment on Vercel) and message will be displayed: 
<img width="1077" alt="Zrzut ekranu 2022-09-30 o 13 34 59" src="https://user-images.githubusercontent.com/5188636/193276073-a3dddbb9-8e27-43a4-9de6-109199c5c46d.png">

- after a few minutes redeployment will finish and user should be able to access configuration view and submit data with the form