### PR TITLE
Update imports from app sdk, not using root path

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@saleor/app-sdk": "0.15.0",
+    "@saleor/app-sdk": "0.18.0",
     "@saleor/macaw-ui": "^0.6.5",
     "@urql/exchange-auth": "^1.0.0",
     "graphql": "^16.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   '@material-ui/core': ^4.12.4
   '@material-ui/icons': ^4.11.3
   '@material-ui/lab': 4.0.0-alpha.61
-  '@saleor/app-sdk': 0.15.0
+  '@saleor/app-sdk': 0.18.0
   '@saleor/macaw-ui': ^0.6.5
   '@types/node': ^18.8.1
   '@types/react': ^18.0.21
@@ -34,7 +34,7 @@ dependencies:
   '@material-ui/core': 4.12.4_rj7ozvcq3uehdlnj3cbwzbi5ce
   '@material-ui/icons': 4.11.3_3mlwvtnnvz4efep55wa5m5dc4e
   '@material-ui/lab': 4.0.0-alpha.61_3mlwvtnnvz4efep55wa5m5dc4e
-  '@saleor/app-sdk': 0.15.0_azq6kxkn3od7qdylwkyksrwopy
+  '@saleor/app-sdk': 0.18.0_azq6kxkn3od7qdylwkyksrwopy
   '@saleor/macaw-ui': 0.6.5_k2kuy4f2rkqfztjzphbs3himfi
   '@urql/exchange-auth': 1.0.0_graphql@16.6.0
   graphql: 16.6.0
@@ -1613,8 +1613,8 @@ packages:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
 
-  /@saleor/app-sdk/0.15.0_azq6kxkn3od7qdylwkyksrwopy:
-    resolution: {integrity: sha512-AqeiyhsukIOtpfhtBgAPW2OFXiK3HLkrjc+EII1nx7PDJ+taKLFoG6c0n2P3AaPA5Qx7Fma+y0FENsGXXGJEjg==}
+  /@saleor/app-sdk/0.18.0_azq6kxkn3od7qdylwkyksrwopy:
+    resolution: {integrity: sha512-kWclPx9738cG7n7bI5P85wrOnCVdkMRuViICygt7xwDlt9IIncMGUwaR07zQ8uCUTvMoesEO96J36d5OGM/QJA==}
     peerDependencies:
       next: ^12
       react: '>=17'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1623,7 +1623,7 @@ packages:
       debug: 4.3.4
       fast-glob: 3.2.12
       graphql: 16.6.0
-      jose: 4.10.0
+      jose: 4.10.3
       next: 12.3.1_biqbaboplfbrettd7655fr4n2y
       node-fetch: 2.6.7
       react: 18.2.0
@@ -3835,8 +3835,8 @@ packages:
       ws: 8.9.0
     dev: true
 
-  /jose/4.10.0:
-    resolution: {integrity: sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==}
+  /jose/4.10.3:
+    resolution: {integrity: sha512-3S4wQnaoJKSAx9uHSoyf8B/lxjs1qCntHWL6wNFszJazo+FtWe+qD0zVfY0BlqJ5HHK4jcnM98k3BQzVLbzE4g==}
     dev: false
 
   /js-sdsl/4.1.5:

--- a/saleor-app.ts
+++ b/saleor-app.ts
@@ -1,4 +1,4 @@
-import { SaleorApp } from "@saleor/app-sdk";
+import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 import { APL, FileAPL, UpstashAPL, VercelAPL } from "@saleor/app-sdk/APL";
 
 /**

--- a/src/pages/api/manifest.ts
+++ b/src/pages/api/manifest.ts
@@ -1,5 +1,5 @@
-import { AppManifest } from "@saleor/app-sdk";
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
+import { AppManifest } from "@saleor/app-sdk/types";
 
 import packageJson from "../../../package.json";
 


### PR DESCRIPTION
This have to be merged after https://github.com/saleor/saleor-app-sdk/pull/98

SDK must be released and bumped