### PR TITLE
Search for gql documents also in the ts/tsx files

### DIFF
--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -1,5 +1,5 @@
 schema: graphql/schema.graphql
-documents: graphql/**/*.graphql
+documents: [graphql/**/*.graphql, src/**/*.ts, src/**/*.tsx]
 extensions:
   codegen:
     overwrite: true


### PR DESCRIPTION
It's quite handy to have the option to specify a query in the ts files, instead of .graphql. 

This pattern is used by async webhook example.