### PR TITLE
Allow Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "schemaVersion": "3.19"
   },
   "engines": {
-    "node": ">=18.17.0 <19",
+    "node": ">=18.17.0 <=20",
     "pnpm": ">=8"
   },
   "dependencies": {


### PR DESCRIPTION
Allow node 20 to be used, since it's the Vercel default version