### PR TITLE
Add workflow to check licenses

### DIFF
--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -4,6 +4,9 @@ on:
     types:
       - opened
       - synchronize
+      # Labels are needed to handle external contributors
+      - labeled
+      - unlabeled
     paths:
       # Self
       - ".github/workflows/check-licenses.yaml"

--- a/.github/workflows/check-licenses.yaml
+++ b/.github/workflows/check-licenses.yaml
@@ -1,0 +1,45 @@
+name: Check Licenses
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      # Self
+      - ".github/workflows/check-licenses.yaml"
+      # Python Ecosystem
+      - "**/pyproject.toml"
+      - "**/setup.py"
+      - "**/requirements*.txt"
+      - "**/Pipfile.lock"
+      - "**/poetry.lock"
+      # JS/TS Ecosystem
+      - "**/package.json"
+      - "**/pnpm-lock.yaml"
+      - "**/package-lock.json"
+
+jobs:
+  default:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: saleor/saleor-internal-actions/.github/workflows/run-license-check.yaml@v1
+    with:
+      # List of ecosystems to scan.
+      ecosystems: >-
+        python
+        javascript
+      # Grant rules (https://github.com/anchore/grant/blob/4362dc22cf5ea9baeccfa59b2863879afe0c30d7/README.md#usage)
+      rules: |
+        # Explicitly allow LGPL as "*GPL*" rule will cause to reject them otherwise.
+        - pattern: "*lgpl*"
+          name: "allow-lgpl"
+          mode: "allow"
+          reason: "LGPL is allowed."
+        - pattern: "*gpl*"
+          name: "deny-gpl"
+          mode: "deny"
+          reason: "GPL licenses are not compatible with BSD-3-Clause"
+        - pattern: "*proprietary*"
+          name: "deny-proprietary"
+          mode: "deny"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "saleor-app-template",
   "version": "1.0.0",
   "private": true,
+  "license": "(BSD-3-Clause AND CC-BY-4.0)",
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",


### PR DESCRIPTION
This adds a workflow that checks our repository does not use non-BSD-3 compatible licenses.

The workflow reviews each pull requests against given rules, and sends a summary.