### PR TITLE
Add setup node to GHA workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,13 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
-          run_install: |
-            - args: [--frozen-lockfile]
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Lint
         run: pnpm lint
       - name: Check types


### PR DESCRIPTION
* This PR adds setup-node action so proper version of Node (22) instead of default (20 for GHA) is used
* It also adds cache via pnpm/action-setup#use-cache-to-reduce-installation-time