### PR TITLE
Force resolving react from node_modules of the app

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,22 @@
+import path from "path";
 import { NextConfig } from "next";
 
 const config: NextConfig = {
   reactStrictMode: true,
+  webpack: (config) => {
+    // When using `pnpm link` for local SDK development, webpack may resolve
+    // react/react-dom from the linked package's node_modules (different version),
+    // causing the "two Reacts" problem. Force resolution to this project's copy.
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...config.resolve?.alias,
+        react: path.resolve("./node_modules/react"),
+        "react-dom": path.resolve("./node_modules/react-dom"),
+      },
+    };
+    return config;
+  },
 };
 
 export default config;


### PR DESCRIPTION
This is fix for local development. When `pnpm link` is used (eg to develop app-sdk), app-sdk is using it's own React, while app is using own. 

This config ensures react is always pointing at React in app's node_modules, not linked package